### PR TITLE
Convert vendor:product integers to hex format

### DIFF
--- a/src/cli/cli_devices.rs
+++ b/src/cli/cli_devices.rs
@@ -84,7 +84,7 @@ pub fn handle_verb(verb: &str, device: &Device) {
 }
 
 fn interface_loop<T: UsbContext>(device_handle: &mut DeviceHandle<T>, enable: bool) {
-    device_handle.device().active_config_descriptor().unwrap().interfaces().enumerate().for_each(|(index, interface)| {
+    device_handle.device().active_config_descriptor().unwrap().interfaces().enumerate().for_each(|(index, _interface)| {
         let index = index as u8;
 
         if enable {

--- a/src/cli/cli_devices.rs
+++ b/src/cli/cli_devices.rs
@@ -84,7 +84,7 @@ pub fn handle_verb(verb: &str, device: &Device) {
 }
 
 fn interface_loop<T: UsbContext>(device_handle: &mut DeviceHandle<T>, enable: bool) {
-    device_handle.device().active_config_descriptor().unwrap().interfaces().enumerate().for_each(|(index, _interface)| {
+    device_handle.device().active_config_descriptor().unwrap().interfaces().enumerate().for_each(|(index, interface)| {
         let index = index as u8;
 
         if enable {

--- a/src/cli/cli_devices_list.rs
+++ b/src/cli/cli_devices_list.rs
@@ -43,7 +43,7 @@ pub fn demo() {
             String::from("Language not found")
         });
 
-        println!("{}  - Bus {} Device {} ID {}:{} ({})",
+        println!("{}  - Bus {} Device {} ID {:04x}:{:04x} ({})",
             index,
             device.bus_number(),
             device.address(),


### PR DESCRIPTION
```
$ lusb-cli list && lsusb

0  - Bus 4 Device 1 ID 1d6b:0003 (xHCI Host Controller)
1  - Bus 3 Device 4 ID 04f2:b6fb (Chicony USB2.0 Camera)
2  - Bus 3 Device 6 ID 046d:c52f (USB Receiver)
3  - Bus 3 Device 5 ID 8087:0026 (Language not found)
4  - Bus 3 Device 13 ID 08bb:2904 (USB Audio CODEC )
5  - Bus 3 Device 1 ID 1d6b:0002 (xHCI Host Controller)
6  - Bus 2 Device 1 ID 1d6b:0003 (xHCI Host Controller)
7  - Bus 1 Device 1 ID 1d6b:0002 (xHCI Host Controller)

Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 003 Device 004: ID 04f2:b6fb Chicony Electronics Co., Ltd Chicony USB2.0 Camera
Bus 003 Device 006: ID 046d:c52f Logitech, Inc. Unifying Receiver
Bus 003 Device 005: ID 8087:0026 Intel Corp. AX201 Bluetooth
Bus 003 Device 013: ID 08bb:2904 Texas Instruments PCM2904 Audio Codec
Bus 003 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
```

Looks good here, if this is your intended behaviour.